### PR TITLE
Fix ordering issues using the contain function

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,10 @@
 # Start avahi services for mdns
 
 class avahi($firewall=false) {
+  contain avahi::package
+  contain avahi::service
 
-  class { 'avahi::package': } ~>
-  class { 'avahi::service': }
+  Class['avahi::package'] ~> Class['avahi::service']
 
   if $firewall {
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -2,10 +2,10 @@ class avahi::package() {
 
   case $::operatingsystem {
     centos,fedora,rhel,redhat: {
-      class { 'avahi::package::redhat': }
+      contain avahi::package::redhat
     }
     debian,ubuntu: {
-      class { 'avahi::package::debian': }
+      contain avahi::package::debian
     }
-  }  
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,11 +2,11 @@ class avahi::service() {
 
   case $::operatingsystem {
     centos,fedora,rhel,redhat: {
-      class { 'avahi::service::redhat': }
+      contain avahi::service::redhat
     }
     debian,ubuntu: {
     }
-  }  
+  }
 
   service { 'avahi-daemon':
     enable => true,


### PR DESCRIPTION
Currently, it's possible Puppet will run the `Service['avahi-daemon']` resource before `Package['avahi-daemon']`, which will fail since avahi-daemon won't exist yet. I fixed this by using the contain function introduced in Puppet 3.4: http://docs.puppetlabs.com/puppet/latest/reference/lang_containment.html

Tested with Puppet 3.4.3
